### PR TITLE
WUI: Fixes to registrar component

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsView.java
@@ -9,7 +9,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.gwtplatform.mvp.client.ViewImpl;
-import cz.metacentrum.perun.wui.client.resources.PerunSession;
 import cz.metacentrum.perun.wui.client.utils.JsUtils;
 import cz.metacentrum.perun.wui.json.JsonEvents;
 import cz.metacentrum.perun.wui.json.managers.RegistrarManager;
@@ -51,7 +50,8 @@ public class AppsView extends ViewImpl implements AppsPresenter.MyView {
 
 	public void draw() {
 
-		RegistrarManager.getApplicationsForUser(PerunSession.getInstance().getUserId(), new JsonEvents() {
+		// make sure we search by identity and user session info
+		RegistrarManager.getApplicationsForUser(0, new JsonEvents() {
 
 			JsonEvents retry = this;
 
@@ -65,7 +65,7 @@ public class AppsView extends ViewImpl implements AppsPresenter.MyView {
 				grid.getLoaderWidget().onError(error, new ClickHandler() {
 					@Override
 					public void onClick(ClickEvent event) {
-						RegistrarManager.getApplicationsForUser(PerunSession.getInstance().getUser().getId(), retry);
+						RegistrarManager.getApplicationsForUser(0, retry);
 					}
 				});
 			}

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
@@ -254,7 +254,8 @@ public class ValidatedEmail extends PerunFormItemEditable {
 	}
 
 	private boolean isCustomSelected() {
-		return getSelect().getSelectedValue().equals(CUSTOM_ID);
+		if (getSelect() != null) getSelect().getSelectedValue().equals(CUSTOM_ID);
+		return false;
 	}
 
 }


### PR DESCRIPTION
WUI: In order to display most of user applications, always search by session info.

- Must be deployed after update to the perun-registrar component.

WUI: Prevent null pointer in case email is not pre-filled from federation

- Check on validated mail form item was stopped by NullPointerException
  when no value was pre-filled from IdP or Perun. Now we assume, that
  "custom" is not selected since it has no effect (select is not visible).
