### PR TITLE
PROFILE: Read app title from config file.

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
@@ -240,6 +240,24 @@ public final class PerunConfiguration {
 	}
 
 	/**
+	 * Get brand title of user profile in current locale. If not present, "en" version is used.
+	 * If property is not set at all, null is returned.
+	 *
+	 * @return Configured title or null
+	 */
+	public static String getBrandProfileTitle() {
+
+		String value = getConfigPropertyString("brand.profile.title."+getCurrentLocaleName());
+		if (value == null || value.isEmpty()) value = getConfigPropertyString("brand.profile.title.en");
+		if (value == null || value.isEmpty()) {
+			return null;
+		} else {
+			return value;
+		}
+
+	}
+
+	/**
 	 * Get brand name in current user locale. If not present, "en" version is used.
 	 * If none is set, Perun brand name is used.
 	 *

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/PerunProfileView.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/PerunProfileView.java
@@ -103,6 +103,11 @@ public class PerunProfileView extends ViewImpl implements PerunProfilePresenter.
 			menuWrapper.setVisible(false);
 		}
 
+		// set Title from property if any
+		if (PerunConfiguration.getBrandProfileTitle() != null) {
+			brand.setText(PerunConfiguration.getBrandProfileTitle());
+		}
+
 		// put logo
 		Image logo = PerunConfiguration.getBrandLogo();
 		logo.setWidth("auto");


### PR DESCRIPTION
Profile app use brand.profile.title.[lang] property to fill title. If not configured "User profile" is used.