### PR TITLE
WUI: Silently skip all actions if AlreadyProcessingException is thrown

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
@@ -303,9 +303,17 @@ public class PerunForm extends FieldSet {
 
 			@Override
 			public void onError(PerunException error) {
-				button.setProcessing(false);
-				button.setEnabled(true);
-				if (onSubmitEvent != null) onSubmitEvent.onError(error);
+
+				// in a case of browser lag, user might submit same application multiple-times
+				// AlreadyProcessingException prevents concurrent run on server and must be
+				// silently skipped in GUI (first successful request will handle all actions)
+				if (!"AlreadyProcessingException".equals(error.getName())) {
+					// some real exception
+					button.setProcessing(false);
+					button.setEnabled(true);
+					if (onSubmitEvent != null) onSubmitEvent.onError(error);
+				}
+
 			}
 
 			@Override


### PR DESCRIPTION
- To prevent user from multiple submission of same application,
  RPC throws AlreadyProcessingException when same application is
  being processed. GUI must silently skip it to wait for original
  request to finish.

  Merge only after: https://github.com/CESNET/perun/pull/1639
  is deployed to production.