### PR TITLE
Customize attributes on Profile personal page

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.wui.client.resources;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.i18n.client.LocaleInfo;
@@ -170,11 +169,28 @@ public final class PerunConfiguration {
 	 *
 	 * @return names of attributes that should be hidden
 	 */
+	@Deprecated
 	public static List<String> getProfilePersonalAttributesToHide() {
 		List<String> attrNames = new ArrayList<>();
 		String data = getConfigPropertyString("profile.personal.hideAttributes");
 		if (data != null) {
 			String[] values = data.replaceAll("\\s+","").split(",");
+			attrNames.addAll(Arrays.asList(values));
+		}
+
+		return attrNames;
+	}
+
+	/**
+	 * Returns list of attributes that should be shown on user profile page
+	 *
+	 * @return names of attributes that should be shown
+	 */
+	public static List<String> getProfilePersonalAttributesToShow() {
+		List<String> attrNames = new ArrayList<>();
+		String data = getConfigPropertyString("profile.personal.showAttributes");
+		if (data != null) {
+			String[] values = data.replaceAll("\\s+", "").split(",");
 			attrNames.addAll(Arrays.asList(values));
 		}
 

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/AttributeDefinition.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/AttributeDefinition.java
@@ -41,6 +41,15 @@ public class AttributeDefinition extends GeneralObject {
 	}
 
 	/**
+	 * Gets display name of an attribute
+	 *
+	 * @return display name
+	 */
+	public final String getDisplayName() {
+		return JsUtils.getNativePropertyString(this, "displayName");
+	}
+
+	/**
 	 * Gets namespace of an attribute (first part of URN)
 	 *
 	 * @return namespace of an attribute

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation.java
@@ -235,4 +235,10 @@ public interface PerunProfileTranslation extends PerunTranslation {
 
 	@DefaultMessage("Public part of key")
 	String publicKey();
+
+	@DefaultMessage("Preferred shells")
+    String preferredShells();
+
+	@DefaultMessage("Bona fide status")
+	String bonaFideStatus();
 }

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
@@ -9,7 +9,9 @@ import com.google.inject.Inject;
 import com.gwtplatform.mvp.client.ViewWithUiHandlers;
 import cz.metacentrum.perun.wui.client.resources.PerunConfiguration;
 import cz.metacentrum.perun.wui.model.PerunException;
+import cz.metacentrum.perun.wui.model.beans.Attribute;
 import cz.metacentrum.perun.wui.model.beans.RichUser;
+import cz.metacentrum.perun.wui.profile.client.resources.PerunProfileResources;
 import cz.metacentrum.perun.wui.profile.client.resources.PerunProfileTranslation;
 import cz.metacentrum.perun.wui.widgets.PerunLoader;
 import org.gwtbootstrap3.client.ui.Alert;
@@ -22,12 +24,17 @@ import org.gwtbootstrap3.client.ui.HelpBlock;
 import org.gwtbootstrap3.client.ui.Input;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.Row;
+import org.gwtbootstrap3.client.ui.constants.ButtonSize;
+import org.gwtbootstrap3.client.ui.constants.ColumnSize;
+import org.gwtbootstrap3.client.ui.constants.Toggle;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Div;
 import org.gwtbootstrap3.client.ui.html.Small;
 import org.gwtbootstrap3.client.ui.html.Text;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * View for displaying personal info about user
@@ -36,11 +43,15 @@ import java.util.List;
  */
 public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> implements PersonalPresenter.MyView {
 
-	private static final String NAME = "name";
-	private static final String ORGANIZATION = "organization";
-	private static final String PREFERRED_EMAIL = "preferredEmail";
-	private static final String PREFERRED_LANGUAGE = "preferredLanguage";
-	private static final String TIME_ZONE = "timezone";
+	private static final Map<String, String> attributeNamesTranslations = new HashMap<>();
+
+	private static final String URN_ORGANIZATION = "urn:perun:user:attribute-def:def:organization";
+	private static final String URN_PREFERRED_LANGUAGE = "urn:perun:user:attribute-def:def:preferredLanguage";
+	private static final String URN_PREFERRED_EMAIL = "urn:perun:user:attribute-def:def:preferredMail";
+	private static final String URN_TIMEZONE = "urn:perun:user:attribute-def:def:timezone";
+	private static final String URN_USER_DISPLAY_NAME = "urn:perun:user:attribute-def:core:displayName";
+	private static final String URN_PREFERRED_SHELLS = "urn:perun:user:attribute-def:def:preferredShells";
+	private static final String URN_BONA_FIDE_STATUS = "urn:perun:user:attribute-def:virt:elixirBonaFideStatus";
 
 	interface PersonalViewUiBinder extends UiBinder<Widget, PersonalView> {
 	}
@@ -59,33 +70,6 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 	Div personalInfo;
 
 	@UiField
-	Column nameLabel;
-	@UiField
-	Text nameData;
-	@UiField
-	Column emailLabel;
-	@UiField
-	Text emailData;
-	@UiField
-	Column orgLabel;
-	@UiField
-	Text orgData;
-	@UiField
-	Column languageLabel;
-	@UiField
-	Text languageData;
-	@UiField
-	Column timezoneLabel;
-	@UiField
-	Text timezoneData;
-
-	@UiField Row nameRow;
-	@UiField Row organizationRow;
-	@UiField Row preferredEmailRow;
-	@UiField Row preferredLanguageRow;
-	@UiField Row timezoneRow;
-
-	@UiField
 	Form updateEmailForm;
 	@UiField
 	Button updateEmailBtn;
@@ -100,8 +84,6 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 	@UiField
 	Alert alreadyEmailRequests;
 	@UiField
-	Button updateEmailModalBtn;
-	@UiField
 	Modal updateEmailModal;
 	@UiField
 	FormLabel updateEmailLabel;
@@ -110,12 +92,7 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 	public PersonalView(PersonalViewUiBinder binder) {
 		initWidget(binder.createAndBindUi(this));
 
-
-		orgLabel.add(new Text(translation.organization()));
-		nameLabel.add(new Text((translation.name())));
-		emailLabel.add(new Text((translation.preferredMail())));
-		languageLabel.add(new Text((translation.preferredLang())));
-		timezoneLabel.add(new Text((translation.timezone())));
+		loadAttributeNamesTranslations();
 
 		updateEmailBtn.addClickHandler((event) ->
 				updateEmailForm.submit()
@@ -127,27 +104,40 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 		});
 
 		updateEmailLoader.getElement().getStyle().setMarginTop(8, Style.Unit.PX);
-		updateEmailModalBtn.setText(translation.updateEmail());
 		updateEmailBtn.setText(translation.sendValidationEmail());
 		updateEmailModal.setTitle(translation.updateEmailModalTitle());
 		updateEmailLabel.setText(translation.newPreferredEmail());
+	}
 
-		applyHideConfiguration();
+	private void loadAttributeNamesTranslations() {
+		attributeNamesTranslations.put(URN_USER_DISPLAY_NAME, translation.name());
+		attributeNamesTranslations.put(URN_ORGANIZATION, translation.organization());
+		attributeNamesTranslations.put(URN_PREFERRED_LANGUAGE, translation.preferredLang());
+		attributeNamesTranslations.put(URN_PREFERRED_EMAIL, translation.preferredMail());
+		attributeNamesTranslations.put(URN_TIMEZONE, translation.timezone());
+		attributeNamesTranslations.put(URN_PREFERRED_SHELLS, translation.preferredShells());
+		attributeNamesTranslations.put(URN_BONA_FIDE_STATUS, translation.bonaFideStatus());
 	}
 
 	@Override
 	public void setUser(RichUser user) {
+		personalInfo.clear();
 		loader.onFinished();
 		loader.setVisible(false);
 		personalInfo.setVisible(true);
 
 		text.setText(user.getFullName());
 
-		setAttribute(user.getFullName(), nameData);
-		setAttribute(user.getOrganization(), orgData);
-		setAttribute(user.getPreferredEmail(), emailData);
-		setAttribute(user.getPreferredLanguage(), languageData);
-		setAttribute(user.getTimezone(), timezoneData);
+		List<String> additionalAttributes = PerunConfiguration.getProfilePersonalAttributesToShow();
+
+		for (String attributeUrn : additionalAttributes) {
+			String value;
+			String defaultName;
+			Attribute attribute = user.getAttribute(attributeUrn);
+			value = attribute == null ? null : attribute.getValue();
+			defaultName = attribute == null ? null : attribute.getDisplayName();
+			addPersonalData(attributeUrn, value, defaultName);
+		}
 	}
 
 	@Override
@@ -225,28 +215,66 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 		}
 	}
 
-	private void applyHideConfiguration() {
+	/**
+	 * Adds user data to overview. If the given value is null then
+	 * '-' is shown. If there is a translated name for given urn,
+	 * then it is used. If there is not, the defaultName is shown.
+	 * If there is not a translated name and the default name is null,
+	 * the name is obtained from given urn.
+	 *
+	 * @param urn attribute urn
+	 * @param value value to be shown
+	 * @param defaultName default name used when there is not a translated name for given urn
+	 */
+	private void addPersonalData(String urn, String value, String defaultName) {
+		Row row = new Row();
+		row.setPaddingBottom(10);
+		Column nameColumn = new Column(ColumnSize.SM_4, ColumnSize.XS_4);
+		nameColumn.addStyleName(PerunProfileResources.INSTANCE.gss().personalInfoLabel());
+		Column valueColumn = new Column(ColumnSize.SM_8, ColumnSize.XS_8);
 
-		checkAttribute(NAME, nameRow);
-		checkAttribute(ORGANIZATION, organizationRow);
-		checkAttribute(PREFERRED_EMAIL, preferredEmailRow);
-		checkAttribute(PREFERRED_LANGUAGE, preferredLanguageRow);
-		checkAttribute(TIME_ZONE, timezoneRow);
-	}
-
-	private void checkAttribute(String name, Row attrRow) {
-		List<String> attrsToHide = PerunConfiguration.getProfilePersonalAttributesToHide();
-		if (attrsToHide.contains(name)) {
-			attrRow.setVisible(false);
+		// check if translated name is available
+		String translatedName = attributeNamesTranslations.get(urn);
+		if (translatedName == null) {
+			if (defaultName != null) {
+				translatedName = defaultName;
+			} else {
+				// parse name from urn
+				String[] split = urn.split(":");
+				if (split.length < 1) {
+					return;
+				}
+				translatedName = split[split.length - 1];
+			}
 		}
-	}
 
-	private void setAttribute(String value, Text label) {
+		Text nameText = new Text(translatedName);
+		Text valueText = new Text();
+
 		if (value == null) {
-			label.setText("-");
+			valueText.setText("-");
 		} else {
-			label.setText(value);
+			valueText.setText(value);
 		}
-	}
 
+		nameColumn.add(nameText);
+		valueColumn.add(valueText);
+
+		row.add(nameColumn);
+		row.add(valueColumn);
+
+		// if it is preferred email, add change button
+		if (URN_PREFERRED_EMAIL.matches(urn)) {
+			Button updateButton = new Button();
+			updateButton.setSize(ButtonSize.EXTRA_SMALL);
+			updateButton.setMarginLeft(10);
+			updateButton.setText(translation.updateEmail());
+			updateButton.setDataTarget("#updateEmailModal");
+			updateButton.setDataToggle(Toggle.MODAL);
+
+			valueColumn.add(updateButton);
+		}
+
+		personalInfo.add(row);
+	}
 }

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.ui.xml
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.ui.xml
@@ -23,38 +23,6 @@
 		<p:PerunLoader visible="false" ui:field="loader" />
 
 		<b.html:Div ui:field="personalInfo" visible="false" paddingTop="20">
-			<b:Row paddingBottom="10" ui:field="nameRow">
-				<b:Column size="SM_4 XS_4" ui:field="nameLabel" addStyleNames="{res.gss.personalInfoLabel}" />
-				<b:Column size="SM_8 XS_8" >
-					<b.html:Text ui:field="nameData" />
-				</b:Column>
-			</b:Row>
-			<b:Row paddingBottom="10" ui:field="organizationRow">
-				<b:Column size="SM_4 XS_4" ui:field="orgLabel" addStyleNames="{res.gss.personalInfoLabel}" />
-				<b:Column size="SM_8 XS_8" >
-					<b.html:Text ui:field="orgData" />
-				</b:Column>
-			</b:Row>
-			<b:Row paddingBottom="10" ui:field="preferredEmailRow">
-				<b:Column size="SM_4 XS_4" ui:field="emailLabel" addStyleNames="{res.gss.personalInfoLabel}" />
-				<b:Column size="SM_8 XS_8" >
-					<b.html:Text ui:field="emailData" />
-					<b:Button ui:field="updateEmailModalBtn" size="EXTRA_SMALL" marginLeft="10" text="update"
-							  dataTarget="#updateEmailModal" dataToggle="MODAL" />
-				</b:Column>
-			</b:Row>
-			<b:Row paddingBottom="10" ui:field="preferredLanguageRow">
-				<b:Column size="SM_4 XS_4" ui:field="languageLabel" addStyleNames="{res.gss.personalInfoLabel}" />
-				<b:Column size="SM_8 XS_8" >
-					<b.html:Text ui:field="languageData" />
-				</b:Column>
-			</b:Row>
-			<b:Row paddingBottom="10" ui:field="timezoneRow">
-				<b:Column size="SM_4 XS_4" ui:field="timezoneLabel" addStyleNames="{res.gss.personalInfoLabel}" />
-				<b:Column size="SM_8 XS_8" >
-					<b.html:Text ui:field="timezoneData" />
-				</b:Column>
-			</b:Row>
 		</b.html:Div>
 
 

--- a/perun-wui-profile/src/main/resources/common/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation_cs.properties
+++ b/perun-wui-profile/src/main/resources/common/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation_cs.properties
@@ -77,3 +77,4 @@ cancel=Zrušit
 sshInvalidPrefixText=Zadána neplatná hodnota klíče. Hodnota musí začínat ''ssh-rsa'', ''ssh-ed25519'', ''ecdsa-sha2-nistp256'', ''ecdsa-sha2-nistp384'' nebo ''ecdsa-sha2-nistp521''.
 sshInvalidNewLinesText=Hodnota klíče nesmí obsahovat více řádků.
 publicKey=Veřejná část klíče
+preferredShells=Preferované shelly


### PR DESCRIPTION
* Now you can customize what attributes are shown in
personal page by setting theirs urns in config file.

* Example: profile.personal.showAttributes=special:user:fullName,
 urn:perun:user:attribute-def:def:organization,
 urn:perun:user:attribute-def:def:preferredLanguage,
 urn:perun:user:attribute-def:def:preferredMail,
 urn:perun:user:attribute-def:def:timezone,
 urn:perun:user:attribute-def:def:preferredShells