### PR TITLE
Fix links on Profile personal page

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.wui.client.resources;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.i18n.client.LocaleInfo;
@@ -705,20 +704,18 @@ public final class PerunConfiguration {
 		if (split.length == 1) {
 			return attribute;
 		}
-		GWT.log(value);
 
 		String[] nextSplit = split[1].split("\\|");
 
 		String enDescription = nextSplit[0].trim();
-		attribute.addDescription("en", enDescription);
-		GWT.log(enDescription);
 		if (nextSplit.length == 1) {
+			enDescription = enDescription.replace("]", "");
+			attribute.addDescription("en", enDescription);
 			return attribute;
 		}
+		attribute.addDescription("en", enDescription);
 
-		GWT.log(nextSplit[1]);
 		String csDescription = nextSplit[1].replace("]", "").trim();
-		GWT.log(csDescription);
 
 		attribute.addDescription("cs", csDescription);
 

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
@@ -283,11 +283,25 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 	 * @return appropriate widget for given text
 	 */
 	private Widget getWidgetForText(String text) {
-		if (text.startsWith("http")) {
-			return new Anchor(text, text);
-		} else {
-			return new Text(text);
+		Span descriptionSpan = new Span();
+
+		Text textEl = new Text();
+
+		for (String s : text.split("\\s+")) {
+			if (s.startsWith("http")) {
+				descriptionSpan.add(textEl);
+				textEl = new Text(" ");
+				descriptionSpan.add(new Anchor(s, s));
+			} else {
+				textEl.setText(textEl.getText() + s + " ");
+			}
 		}
+
+		if (textEl.getText().trim().length() > 0) {
+			descriptionSpan.add(textEl);
+		}
+
+		return descriptionSpan;
 	}
 
 	private Column createLabelColumn(PersonalAttribute personalAttribute, String defaultName) {


### PR DESCRIPTION
* Links were not displayed properly when they were not at the beginning
of the description text.

* Fixed attribute description when there was only the english
value with displayed ']'

* Removed some debug logs